### PR TITLE
fixed #5 to view the api page, type /api after localhost address

### DIFF
--- a/freegeek/settings.py
+++ b/freegeek/settings.py
@@ -48,7 +48,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-
+    'rest_framework',
     'freegeek',
     'diary',
     'datetimewidget',
@@ -121,6 +121,12 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',
+    ],
+
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/

--- a/freegeek/urls.py
+++ b/freegeek/urls.py
@@ -18,10 +18,28 @@ from django.contrib import admin
 from django.conf.urls import include
 import django.contrib.auth.views
 from diary import urls as diary_urls
+from django.contrib.auth.models import User
+from rest_framework import routers, serializers, viewsets
+
+
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = User
+        fields = ('url', 'username', 'email', 'is_staff')
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+
+router = routers.DefaultRouter()
+router.register(r'users', UserViewSet)
 
 
 urlpatterns = [
+    url(r'^api/?', include(router.urls)),
     url(r'^admin/', include(admin.site.urls)),
+    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^accounts/login/$', django.contrib.auth.views.login),
     url(r'^accounts/logout/$',
         django.contrib.auth.views.logout,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ django>=1.8.18<1.9.0
 django_extensions>=1.8.1<1.9.0
 djangorestframework>=3.6.3<3.7.0
 django-diary>=0.3.4<0.4.0
+django-filter>=1.0.1
 psycopg2>=2.7.3<2.8.0
 


### PR DESCRIPTION
Connected to REST API. To view the API page you need to type "/api" after localhost:<portnumber>.
Also added django-filter to requirements.txt