### PR TITLE
Fixed a date input bug and a broken link

### DIFF
--- a/freegeek/settings.py
+++ b/freegeek/settings.py
@@ -151,7 +151,7 @@ REST_FRAMEWORK = {
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'en-gb'
 
 TIME_ZONE = 'UTC'
 
@@ -160,7 +160,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -12,7 +12,7 @@
   <div id="nav">
       <ul id="nav-list">
           <li> <a href="/"> Home </a></li>
-          <li> <a href="diary/home.html"> Calendar</a></li>
+          <li> <a href="/diary/home.html"> Calendar</a></li>
           {% if user.is_authenticated %}
           <li> <a href="{% url 'profile_page' user.username %}">{{ user.username }}'s Profile</a></li>
           {% endif %}


### PR DESCRIPTION
Turns out the date format is controlled by the language code, so switching to `en-gb` allows date inputs with the local format.

This may be a good way to get things working for now, but forking or vendoring `django-diary` is probably the way to go in the future so that the frontend date component always produces output that the backend understands.

Also fixed a link that wouldn't work because it was relative.